### PR TITLE
Add links to background documents on the Information page

### DIFF
--- a/_pages/information.md
+++ b/_pages/information.md
@@ -10,7 +10,7 @@ permalink: /information/
 #### Should we still worry about lead?
 
 A report was written for the Royal Society of Chemistry that provides a background on lead exposure and toxicity. 
-[Should we still worry about lead](https://leappalliance.org.uk/wp-content/uploads/2025/03/Should-we-still-worry-about-lead-i1.pdf)].
+[Should we still worry about lead](https://leappalliance.org.uk/wp-content/uploads/2025/03/Should-we-still-worry-about-lead-i1.pdf).
 
 ### Publications
 

--- a/_pages/information.md
+++ b/_pages/information.md
@@ -16,7 +16,7 @@ A report was written for the Royal Society of Chemistry that provides a backgrou
 
 #### The lead landscape in the UK
 
-This Powerpoint presentation, with voiceover, prepared for the [Lead & Healthy Housing Conference] (https://leappalliance.org.uk/wp-content/uploads/2025/02/LHHC-conference-d0.3.pptx) in the USA explains the source of lead exposure in the UK and describes the related regulations. 
+This Powerpoint presentation, with voiceover, prepared for the [Lead & Healthy Housing Conference](https://leappalliance.org.uk/wp-content/uploads/2025/02/LHHC-conference-d0.3.pptx) in the USA explains the source of lead exposure in the UK and describes the related regulations. 
 
 ### Links
 For more information about lead exposure and poisoning prevention see the [LEAPP Alliance website](https://leappalliance.org.uk/).

--- a/_pages/information.md
+++ b/_pages/information.md
@@ -8,10 +8,9 @@ permalink: /information/
 ### Background Documents
 #### Should we still worry about lead?
 The document at this link was written for the Royal Society of Chemistry and provides a background on lead exposure and toxicity. 
-[Should we still worry about lead i1.pdf](https://github.com/user-attachments/files/19053304/Should.we.still.worry.about.lead.i1.pdf).
-
+Should we still worry about lead i1.pdf (https://leappalliance.org.uk/wp-content/uploads/2025/03/Should-we-still-worry-about-lead-i1.pdf)
 ### Publications
 [Related publications]
 
 ### Links
-[Relevant resources]
+For more information about lead exposure and poisoning prevention see the LEAPP Alliance website (https://leappalliance.org.uk/).

--- a/_pages/information.md
+++ b/_pages/information.md
@@ -6,12 +6,17 @@ permalink: /information/
 ## Additional Resources
 
 ### Background Documents
+
 #### Should we still worry about lead?
-The document at this link was written for the Royal Society of Chemistry and provides a background on lead exposure and toxicity. 
-Should we still worry about lead i1.pdf (https://leappalliance.org.uk/wp-content/uploads/2025/03/Should-we-still-worry-about-lead-i1.pdf).
+
+A report was written for the Royal Society of Chemistry that provides a background on lead exposure and toxicity. 
+[Should we still worry about lead i1.pdf] (https://leappalliance.org.uk/wp-content/uploads/2025/03/Should-we-still-worry-about-lead-i1.pdf).
 
 ### Publications
-[Related publications]
+
+#### The lead landscape in the UK
+
+This Powerpoint presentation, with voiceover, prepared for the [Lead & Healthy Housing Conference] (https://leappalliance.org.uk/wp-content/uploads/2025/02/LHHC-conference-d0.3.pptx) in the USA explains the source of lead exposure in the UK and describes the related regulations. 
 
 ### Links
 For more information about lead exposure and poisoning prevention see the [LEAPP Alliance website](https://leappalliance.org.uk/).

--- a/_pages/information.md
+++ b/_pages/information.md
@@ -16,7 +16,7 @@ A report was written for the Royal Society of Chemistry that provides a backgrou
 
 #### The lead landscape in the UK
 
-This Powerpoint presentation, with voiceover, prepared for the [Lead & Healthy Housing Conference](https://leappalliance.org.uk/wp-content/uploads/2025/02/LHHC-conference-d0.3.pptx) in the USA explains the source of lead exposure in the UK and describes the related regulations. 
+This Powerpoint presentation, with voiceover, prepared for the [Lead & Healthy Housing Conference](https://leappalliance.org.uk/wp-content/uploads/2025/02/LHHC-conference-d0.3.pptx) in the USA explains the sources of lead exposure in the UK and describes the related regulations. 
 
 ### Links
 For more information about lead exposure and poisoning prevention see the [LEAPP Alliance website](https://leappalliance.org.uk/).

--- a/_pages/information.md
+++ b/_pages/information.md
@@ -6,7 +6,8 @@ permalink: /information/
 ## Additional Resources
 
 ### Background Documents
-[Key documents]
+The document found at this link was written for the Royal Society of Chemistry and provides a background on lead exposure and toxicity. 
+[Should we still worry about lead i1.pdf]([https://github.com/user-attachments/files/19053304/Should.we.still.worry.about.lead.i1.pdf](https://leappalliance.org.uk/wp-content/uploads/2025/03/Should-we-still-worry-about-lead-i1.pdf))
 
 ### Publications
 [Related publications]

--- a/_pages/information.md
+++ b/_pages/information.md
@@ -10,7 +10,7 @@ permalink: /information/
 #### Should we still worry about lead?
 
 A report was written for the Royal Society of Chemistry that provides a background on lead exposure and toxicity. 
-[Should we still worry about lead (https://leappalliance.org.uk/wp-content/uploads/2025/03/Should-we-still-worry-about-lead-i1.pdf)].
+[Should we still worry about lead](https://leappalliance.org.uk/wp-content/uploads/2025/03/Should-we-still-worry-about-lead-i1.pdf)].
 
 ### Publications
 

--- a/_pages/information.md
+++ b/_pages/information.md
@@ -10,7 +10,7 @@ permalink: /information/
 #### Should we still worry about lead?
 
 A report was written for the Royal Society of Chemistry that provides a background on lead exposure and toxicity. 
-[Should we still worry about lead i1.pdf] (https://leappalliance.org.uk/wp-content/uploads/2025/03/Should-we-still-worry-about-lead-i1.pdf).
+[Should we still worry about lead (https://leappalliance.org.uk/wp-content/uploads/2025/03/Should-we-still-worry-about-lead-i1.pdf)].
 
 ### Publications
 

--- a/_pages/information.md
+++ b/_pages/information.md
@@ -6,8 +6,8 @@ permalink: /information/
 ## Additional Resources
 
 ### Background Documents
-The document found at this link was written for the Royal Society of Chemistry and provides a background on lead exposure and toxicity. 
-[Should we still worry about lead i1.pdf]([https://github.com/user-attachments/files/19053304/Should.we.still.worry.about.lead.i1.pdf](https://leappalliance.org.uk/wp-content/uploads/2025/03/Should-we-still-worry-about-lead-i1.pdf))
+The document at this link was written for the Royal Society of Chemistry and provides a background on lead exposure and toxicity. 
+[Should we still worry about lead i1.pdf](https://github.com/user-attachments/files/19053304/Should.we.still.worry.about.lead.i1.pdf)]
 
 ### Publications
 [Related publications]

--- a/_pages/information.md
+++ b/_pages/information.md
@@ -8,9 +8,10 @@ permalink: /information/
 ### Background Documents
 #### Should we still worry about lead?
 The document at this link was written for the Royal Society of Chemistry and provides a background on lead exposure and toxicity. 
-Should we still worry about lead i1.pdf (https://leappalliance.org.uk/wp-content/uploads/2025/03/Should-we-still-worry-about-lead-i1.pdf)
+Should we still worry about lead i1.pdf (https://leappalliance.org.uk/wp-content/uploads/2025/03/Should-we-still-worry-about-lead-i1.pdf).
+
 ### Publications
 [Related publications]
 
 ### Links
-For more information about lead exposure and poisoning prevention see the LEAPP Alliance website (https://leappalliance.org.uk/).
+For more information about lead exposure and poisoning prevention see the [LEAPP Alliance website](https://leappalliance.org.uk/).

--- a/_pages/information.md
+++ b/_pages/information.md
@@ -7,7 +7,7 @@ permalink: /information/
 
 ### Background Documents
 The document at this link was written for the Royal Society of Chemistry and provides a background on lead exposure and toxicity. 
-[Should we still worry about lead i1.pdf](https://github.com/user-attachments/files/19053304/Should.we.still.worry.about.lead.i1.pdf)]
+[Should we still worry about lead i1.pdf](https://github.com/user-attachments/files/19053304/Should.we.still.worry.about.lead.i1.pdf).
 
 ### Publications
 [Related publications]

--- a/_pages/information.md
+++ b/_pages/information.md
@@ -6,6 +6,7 @@ permalink: /information/
 ## Additional Resources
 
 ### Background Documents
+#### Should we still worry about lead?
 The document at this link was written for the Royal Society of Chemistry and provides a background on lead exposure and toxicity. 
 [Should we still worry about lead i1.pdf](https://github.com/user-attachments/files/19053304/Should.we.still.worry.about.lead.i1.pdf).
 


### PR DESCRIPTION
I had branched the repository, but now want to merge my changes into the base repository. The net result of my additions is below, but I guess this should also appear in the pull request. 

Tim


---
layout: page
title: Pb Info 
permalink: /information/
---
## Additional Resources

### Background Documents

#### Should we still worry about lead?

A report was written for the Royal Society of Chemistry that provides a background on lead exposure and toxicity. 
[Should we still worry about lead](https://leappalliance.org.uk/wp-content/uploads/2025/03/Should-we-still-worry-about-lead-i1.pdf).

### Publications

#### The lead landscape in the UK

This Powerpoint presentation, with voiceover, prepared for the [Lead & Healthy Housing Conference](https://leappalliance.org.uk/wp-content/uploads/2025/02/LHHC-conference-d0.3.pptx) in the USA explains the sources of lead exposure in the UK and describes the related regulations. 

### Links
For more information about lead exposure and poisoning prevention see the [LEAPP Alliance website](https://leappalliance.org.uk/).