### PR TITLE
Update resource page to use direct PDF links

### DIFF
--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -5,11 +5,7 @@ permalink: /resources/
 ---
 ## Project resources
 ### Participant information sheet
-<iframe src="/files/2.2-ECLIPS_PIS_v1.0.pdf" width="100%" height="600px" style="border: none;">
-  <p>If your browser does not support iframes. You can <a href="/files/2.2-ECLIPS_PIS_v1.0.pdf">download the PDF</a> instead.</p>
-</iframe>
+See [Participant information sheet](https://github.com/fditraglia/leadsafefutures/blob/22-changing-display-of-pdfs-on-resources-page/files/2.2-ECLIPS_PIS_v1.0.pdf)
 
 ### Research participant privacy notice
-<iframe src="/files/2.3-2019ResearchParticipantPrivacyNoticev1.0.pdf" width="100%" height="600px" style="border: none;">
-  <p>If your browser does not support iframes. You can <a href="/files/files/2.3-2019ResearchParticipantPrivacyNoticev1.0.pdf">download the PDF</a> instead.</p>
-</iframe>
+See [Participant privacy notice](https://github.com/fditraglia/leadsafefutures/blob/22-changing-display-of-pdfs-on-resources-page/files/2.3-2019ResearchParticipantPrivacyNoticev1.0.pdf)


### PR DESCRIPTION
Replaced iframe embeds with direct links to PDF files.